### PR TITLE
Added how to build the apps on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Powered by [Ditto](https://ditto.live/).
 * Invite ground staff for additional communication
 
 
+## How to build the apps
+
+### iOS
+
+1. Run `cp .env.template .env` at the root directory
+1. Edit `.env` to add environment variables
+1. Open the app project on Xcode and clean (<kbd>Command</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd>)
+1. Build (<kbd>Command</kbd> + <kbd>B</kbd>)
+    - This will generate `Env.swift`
+
+### Android
+
+1. Open `/Android/gradle.properties` and add environment variables
+1. Build the app normally
+
+
 ## License
 
 MIT


### PR DESCRIPTION
Closes #18 

- `.env`, `Env.swift`, and `gradle.properties` are git-ignored and need to continue that way because they contain environment variables.
- The environment variables are listed on the notion page, which only Ditto members have access: https://www.notion.so/getditto/Environment-Variables-78261e05a2b44a299ee388f06e9ff86a