### PR TITLE
update Ditto to v4.5

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -58,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation "live.ditto:ditto:4.4.4"
+    implementation "live.ditto:ditto:4.5.4"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/iOS/SkyService.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/SkyService.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "cc825b447b6292cc0a4a2f7e25d4fae0e3bfb1a8",
-        "version" : "4.4.4"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {


### PR DESCRIPTION
Update to v4.5, then will push update to app store. This will be a transition period for users to update to v4.5 so when we publish the DQL version it will reduce the risk of breaking.